### PR TITLE
Update Dagger version and usage to reduce overhead.

### DIFF
--- a/app/dagger/ApplicationComponent.java
+++ b/app/dagger/ApplicationComponent.java
@@ -14,4 +14,10 @@ import javax.inject.Singleton;
 })
 public interface ApplicationComponent {
     play.Application application();
+
+    @Component.Builder
+    interface Builder {
+        @BindsInstance Builder context(play.ApplicationLoader.Context context);
+        ApplicationComponent build();
+    }
 }

--- a/app/dagger/ApplicationLoaderContextModule.java
+++ b/app/dagger/ApplicationLoaderContextModule.java
@@ -1,29 +1,11 @@
 package dagger;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Objects;
-
 @Module
-public class ApplicationLoaderContextModule {
+public abstract class ApplicationLoaderContextModule {
 
-    private final play.ApplicationLoader.Context javaContext;
-
-    @Inject
-    public ApplicationLoaderContextModule(play.ApplicationLoader.Context context){
-        this.javaContext = Objects.requireNonNull(context);
-    }
-
-    @Singleton
     @Provides
-    public play.api.ApplicationLoader.Context providesScalaContext() {
-        return this.javaContext.asScala();
-    }
-
-    @Singleton
-    @Provides
-    public play.ApplicationLoader.Context providesJavaContext() {
-        return javaContext;
+    public static play.api.ApplicationLoader.Context providesScalaContext(play.ApplicationLoader.Context context) {
+        return context.asScala();
     }
 
 }

--- a/app/dagger/ApplicationModule.java
+++ b/app/dagger/ApplicationModule.java
@@ -3,10 +3,10 @@ package dagger;
 import play.Application;
 
 @Module
-public class ApplicationModule {
+public abstract class ApplicationModule {
 
     @Provides
-    public Application providesApplication(MyComponentsFromContext myComponentsFromContext) {
+    public static Application providesApplication(MyComponentsFromContext myComponentsFromContext) {
         return myComponentsFromContext.application();
     }
 

--- a/app/dagger/ClockModule.java
+++ b/app/dagger/ClockModule.java
@@ -6,10 +6,10 @@ import java.time.Clock;
  * A module that provides a clock implementation.
  */
 @Module
-public class ClockModule {
+public abstract class ClockModule {
 
     @Provides
-    public Clock clock() {
+    public static Clock clock() {
         return java.time.Clock.systemUTC();
     }
 

--- a/app/dagger/MyApplicationLoader.java
+++ b/app/dagger/MyApplicationLoader.java
@@ -21,7 +21,7 @@ public class MyApplicationLoader implements ApplicationLoader {
         opt.ifPresent(lc -> lc.configure(context.environment(), context.initialConfig(), emptyMap()));
 
         ApplicationComponent applicationComponent = DaggerApplicationComponent.builder()
-                .applicationLoaderContextModule(new ApplicationLoaderContextModule(context))
+                .context(context)
                 .build();
 
         return applicationComponent.application();

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ scalaVersion := "2.12.2"
 
 libraryDependencies += ws
 
-libraryDependencies += "com.google.dagger" % "dagger" % "2.10"
-libraryDependencies += "com.google.dagger" % "dagger-compiler" % "2.10"
+libraryDependencies += "com.google.dagger" % "dagger" % "2.11"
+libraryDependencies += "com.google.dagger" % "dagger-compiler" % "2.11"
 
 javacOptions in Compile := { (managedSourceDirectories in Compile).value.head.mkdirs(); javacOptions.value }
 


### PR DESCRIPTION
* Abstract modules do not require Dagger to create instance.
* Stateless providers can be made static.
* Using `@BindsInstance` places an instance into the graph without requiring a module instance.
* Remove scoping from bindings which don't need it.