### PR TITLE
Upgrade branch 2.7.x using TemplateControl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ scalaVersion := "2.12.7"
 
 libraryDependencies += ws
 
-libraryDependencies += "com.google.dagger" % "dagger" % "2.19"
-libraryDependencies += "com.google.dagger" % "dagger-compiler" % "2.19"
+libraryDependencies += "com.google.dagger" % "dagger" % "2.16"
+libraryDependencies += "com.google.dagger" % "dagger-compiler" % "2.16"
 
 javacOptions in Compile := { (managedSourceDirectories in Compile).value.head.mkdirs(); javacOptions.value }
 


### PR DESCRIPTION
```
Updated with template-control on 2018-11-29T20:26:47.950Z
  **build.sbt:
    libraryDependencies += "com.google.dagger" % "dagger" % "2.16"
  **build.sbt:
    libraryDependencies += "com.google.dagger" % "dagger-compiler" % "2.16"

```
          